### PR TITLE
Delete-Repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ RepoMaster is a Flask-based web application designed to interact with the GitHub
   - Endpoints to retrieve and display issues for a repository.
   - Options to create new issues, close existing ones, or perform other basic issue management tasks.
 
-### 3. Delete Repositories (Planned)
+### 3. Delete Repositories (Available)
 - **Route:** `/delete_repo`
 - **Functionality:** Allows users to select and delete multiple repositories.
 - **Planned Features:**

--- a/app/controllers/repo_controller.py
+++ b/app/controllers/repo_controller.py
@@ -3,28 +3,22 @@
 import requests
 import logging
 from flask import session
-from .auth import get_installation_access_token
+from app.controllers.auth_controller import get_installation_access_token
 
 def delete_repository(repos_to_delete):
-    """
-    Deletes GitHub repositories.
+    """Deletes GitHub repositories."""
 
-    Args:
-        repos_to_delete (list): A list of repository names to delete.
+    deleted_repos = []
+    username = session.get("username", "TgkCapture")  
+    access_token = get_installation_access_token()
 
-    Returns:
-        str: A message indicating which repositories were deleted successfully, or an error message.
-    """
-    access_token = get_installation_access_token() 
     if not access_token:
         logging.error("Access token is missing. Cannot delete GitHub repositories.")
-        return "Failed to retrieve access token. Cannot proceed with deletion."
-
-    github_username = session.get("username", "TgkCapture")  # Default fallback username
-    deleted_repos = []
+        return "Access token missing. Cannot delete repositories."
 
     for repo_name in repos_to_delete:
-        delete_url = f'https://api.github.com/repos/{github_username}/{repo_name}'
+        delete_url = f'https://api.github.com/repos/{username}/{repo_name}'
+
         headers = {
             'Authorization': f'Bearer {access_token}',
             'Accept': 'application/vnd.github.v3+json'
@@ -34,16 +28,13 @@ def delete_repository(repos_to_delete):
             response = requests.delete(delete_url, headers=headers, timeout=60)
             response.raise_for_status()
 
-            if response.status_code == 204:  # No content (successful deletion)
-                logging.info(f"Repository '{github_username}/{repo_name}' deleted successfully.")
+            if response.status_code == 204:
+                logging.info(f"Repository {repo_name} deleted successfully.")
                 deleted_repos.append(repo_name)
-            else:
-                logging.warning(f"Unexpected response while deleting repository '{repo_name}': {response.status_code}")
         except requests.exceptions.RequestException as e:
-            logging.error(f"Failed to delete repository '{repo_name}': {e}")
+            logging.error(f"Failed to delete repository {repo_name}: {e}")
 
     if deleted_repos:
-        return f"Repositories '{', '.join(deleted_repos)}' deleted successfully."
+        return f"Repositories '{', '.join(deleted_repos)}' deleted successfully"
     else:
-        return "No repositories were deleted. Please check the repository names and try again."
-
+        return "No repositories were deleted."

--- a/app/controllers/repo_controller.py
+++ b/app/controllers/repo_controller.py
@@ -1,24 +1,32 @@
 """repo_controller.py
 """
-import os
 import requests
-from flask import Blueprint
-
-repo_controller = Blueprint('repo', __name__)
-
-github_username = os.environ.get('GITHUB_USERNAME')
-github_token = os.environ.get('GITHUB_TOKEN')
+import logging
+from flask import session
+from .auth import get_installation_access_token
 
 def delete_repository(repos_to_delete):
-    """Deletes GitHub repositories."""
+    """
+    Deletes GitHub repositories.
 
+    Args:
+        repos_to_delete (list): A list of repository names to delete.
+
+    Returns:
+        str: A message indicating which repositories were deleted successfully, or an error message.
+    """
+    access_token = get_installation_access_token() 
+    if not access_token:
+        logging.error("Access token is missing. Cannot delete GitHub repositories.")
+        return "Failed to retrieve access token. Cannot proceed with deletion."
+
+    github_username = session.get("username", "TgkCapture")  # Default fallback username
     deleted_repos = []
 
     for repo_name in repos_to_delete:
         delete_url = f'https://api.github.com/repos/{github_username}/{repo_name}'
-
         headers = {
-            'Authorization': f'token {github_token}',
+            'Authorization': f'Bearer {access_token}',
             'Accept': 'application/vnd.github.v3+json'
         }
 
@@ -26,13 +34,16 @@ def delete_repository(repos_to_delete):
             response = requests.delete(delete_url, headers=headers, timeout=60)
             response.raise_for_status()
 
-            if response.status_code == 204:
+            if response.status_code == 204:  # No content (successful deletion)
+                logging.info(f"Repository '{github_username}/{repo_name}' deleted successfully.")
                 deleted_repos.append(repo_name)
+            else:
+                logging.warning(f"Unexpected response while deleting repository '{repo_name}': {response.status_code}")
         except requests.exceptions.RequestException as e:
-            print(f"Failed to delete repository {github_username}/{repo_name}: {e}")
+            logging.error(f"Failed to delete repository '{repo_name}': {e}")
 
     if deleted_repos:
-        return f"Repositories '{', '.join(deleted_repos)}' deleted successfully"
+        return f"Repositories '{', '.join(deleted_repos)}' deleted successfully."
     else:
-        return "No Repos were Deleted"
+        return "No repositories were deleted. Please check the repository names and try again."
 

--- a/app/routes/main_routes.py
+++ b/app/routes/main_routes.py
@@ -130,7 +130,7 @@ def delete_repositories():
 
     if request.method == 'GET':
         # Fetch and display repositories
-        repositories = get_github_repositories("TgkCapture", get_installation_access_token())
+        repositories = get_github_repositories("TgkCapture", get_installation_access_token()) #TODO: retrieve username dynamically
         if repositories:
             return render_template('delete_repo.html', repositories=repositories)
         else:

--- a/app/routes/main_routes.py
+++ b/app/routes/main_routes.py
@@ -2,7 +2,7 @@
 """
 import logging
 import os
-from flask import Blueprint, render_template, request, redirect, url_for, session
+from flask import Blueprint, render_template, request, redirect, url_for, session, flash
 from app.controllers.auth_controller import get_installation_access_token, is_user_logged_in, get_jwt
 from app.controllers.github_controller import get_github_repositories
 from app.controllers.issues_controller import get_github_issues, create_github_issue, close_github_issue

--- a/app/templates/delete_repo.html
+++ b/app/templates/delete_repo.html
@@ -57,7 +57,7 @@
 
     <!-- Check if repositories exist -->
     {% if repositories %}
-        <form method="POST" action="/delete_repo">
+        <form method="POST" action="/delete_repo" id="deleteForm">
             <ul>
                 {% for repo in repositories %}
                     <li>
@@ -75,5 +75,27 @@
     {% else %}
         <p class="no-repos">No repositories found to delete.</p>
     {% endif %}
+
+    <script>
+        document.getElementById('deleteForm').addEventListener('submit', function(event) {
+            const selectedRepos = Array.from(
+                document.querySelectorAll('input[name="repo_to_delete[]"]:checked')
+            ).map(checkbox => checkbox.value);
+
+            if (selectedRepos.length === 0) {
+                alert("Please select at least one repository to delete.");
+                event.preventDefault();
+                return;
+            }
+
+            const confirmDeletion = confirm(
+                `Are you sure you want to delete the following repositories?\n\n${selectedRepos.join(', ')}`
+            );
+
+            if (!confirmDeletion) {
+                event.preventDefault();
+            }
+        });
+    </script>
 </body>
 </html>

--- a/app/templates/delete_repo.html
+++ b/app/templates/delete_repo.html
@@ -1,16 +1,69 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Delete Repositories</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 20px;
+            padding: 0;
+            background-color: #f4f4f9;
+        }
+        h1 {
+            color: #333;
+        }
+        form {
+            background: #ffffff;
+            padding: 20px;
+            border: 1px solid #ddd;
+            border-radius: 8px;
+            max-width: 600px;
+            margin: auto;
+        }
+        ul {
+            list-style-type: none;
+            padding: 0;
+        }
+        li {
+            background: #f9f9f9;
+            margin: 10px 0;
+            padding: 10px;
+            border-radius: 4px;
+            display: flex;
+            align-items: center;
+        }
+        input[type="checkbox"] {
+            margin-right: 10px;
+        }
+        input[type="submit"] {
+            background-color: #d9534f;
+            color: #ffffff;
+            border: none;
+            padding: 10px 20px;
+            font-size: 16px;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        input[type="submit"]:hover {
+            background-color: #c9302c;
+        }
+        .repo-description {
+            color: #666;
+            font-size: 14px;
+        }
+    </style>
 </head>
 <body>
     <h1>Delete Repositories</h1>
-    <form method="post" action="/delete_repo">
+    <form method="POST" action="{{ url_for('main.delete_repositories') }}">
         <ul>
             {% for repo in repositories %}
                 <li>
-                    <input type="checkbox" name="repo_to_delete[]" value="{{ repo.name }}">
-                    {{ repo.name }} - {{ repo.description }}
+                    <input type="checkbox" name="repos" value="{{ repo.name }}">
+                    <strong>{{ repo.name }}</strong> 
+                    <span class="repo-description">- {{ repo.description }}</span>
                 </li>
             {% endfor %}
         </ul>

--- a/app/templates/delete_repo.html
+++ b/app/templates/delete_repo.html
@@ -8,29 +8,25 @@
         body {
             font-family: Arial, sans-serif;
             margin: 20px;
-            padding: 0;
-            background-color: #f4f4f9;
         }
         h1 {
             color: #333;
         }
         form {
-            background: #ffffff;
-            padding: 20px;
-            border: 1px solid #ddd;
-            border-radius: 8px;
-            max-width: 600px;
-            margin: auto;
+            margin-top: 20px;
         }
         ul {
-            list-style-type: none;
+            list-style: none;
             padding: 0;
         }
         li {
-            background: #f9f9f9;
             margin: 10px 0;
             padding: 10px;
+            background-color: #f9f9f9;
+            border: 1px solid #ddd;
             border-radius: 4px;
+        }
+        label {
             display: flex;
             align-items: center;
         }
@@ -38,36 +34,46 @@
             margin-right: 10px;
         }
         input[type="submit"] {
-            background-color: #d9534f;
-            color: #ffffff;
-            border: none;
+            margin-top: 20px;
             padding: 10px 20px;
             font-size: 16px;
+            background-color: #dc3545;
+            color: white;
+            border: none;
             border-radius: 4px;
             cursor: pointer;
         }
         input[type="submit"]:hover {
-            background-color: #c9302c;
+            background-color: #c82333;
         }
-        .repo-description {
-            color: #666;
-            font-size: 14px;
+        .no-repos {
+            color: #888;
+            font-style: italic;
         }
     </style>
 </head>
 <body>
     <h1>Delete Repositories</h1>
-    <form method="POST" action="{{ url_for('main.delete_repositories') }}">
-        <ul>
-            {% for repo in repositories %}
-                <li>
-                    <input type="checkbox" name="repos" value="{{ repo.name }}">
-                    <strong>{{ repo.name }}</strong> 
-                    <span class="repo-description">- {{ repo.description }}</span>
-                </li>
-            {% endfor %}
-        </ul>
-        <input type="submit" value="Delete Selected Repositories">
-    </form>
+
+    <!-- Check if repositories exist -->
+    {% if repositories %}
+        <form method="POST" action="/delete_repo">
+            <ul>
+                {% for repo in repositories %}
+                    <li>
+                        <label>
+                            <input type="checkbox" name="repo_to_delete[]" value="{{ repo.name }}">
+                            <strong>{{ repo.name }}</strong>
+                            <br>
+                            <span>{{ repo.description or "No description available" }}</span>
+                        </label>
+                    </li>
+                {% endfor %}
+            </ul>
+            <input type="submit" value="Delete Selected Repositories">
+        </form>
+    {% else %}
+        <p class="no-repos">No repositories found to delete.</p>
+    {% endif %}
 </body>
 </html>


### PR DESCRIPTION
### Pull Request: Add `/delete_repo` Endpoint for Repository Deletion

#### Description:
- Implemented a new endpoint `/delete_repo` to handle repository deletion requests.
- Added a confirmation mechanism in the UI to prompt users before proceeding with deletion.
- Updated `delete_repository` functionality in `repo_controller.py` to dynamically retrieve GitHub credentials for API requests.
- Enhanced the `delete_repo.html` template with:
  - A dynamic list of repositories.
  - A client-side confirmation dialog to confirm deletion of selected repositories.
  - Validation to ensure at least one repository is selected before form submission.
